### PR TITLE
Fix URL path when using baseURL

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,7 +9,7 @@ pygmentsCodefences = true
 pygmentsStyle = "native"
 
 [taxonomies]
-    category = "categories"  
+    category = "categories"
     tag = "tags"
 
 [permalinks]

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -13,5 +13,3 @@
   </main>
 
 {{ partial "footer" . }}
-
-  

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -13,7 +13,7 @@
           <sup>({{ $value.Count }})</sup>
        </span>
       </li>
-    </ul>   
+    </ul>
     {{ end }}
   </div>
 

--- a/layouts/taxonomy/category.terms.html
+++ b/layouts/taxonomy/category.terms.html
@@ -8,7 +8,7 @@
     {{ range $key, $value := .Data.Terms.Alphabetical }}
     <ul class="category-item">
       <li>
-        <a href="{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
+        <a href="{{ $.Site.BaseURL }}/{{ $.Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a>
         <span class="category-item-count">
           <sup>({{ $value.Count }})</sup>
        </span>


### PR DESCRIPTION
Added the baseURL to each category on the 'categories' page. Seems like each tag on the 'tags' page also now works with baseURL (not sure what I did there). Also changed some whitespacing to match the formatting of everything else in this repository. 

I love this theme! Let me know if this is O.K. 😃 