### PR TITLE
changes the posts directory to post

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <main class="content">
 
   <div class="list">
-     {{ range (.Paginate ((where .Data.Pages "Type" "post").GroupByDate "2006")).PageGroups }}    
+     {{ range (.Paginate ((where .Data.Pages "Type" "posts").GroupByDate "2006")).PageGroups }}    
   <h2 class="list-title">{{ .Key }}</h2>
     {{ range .Pages }}
     


### PR DESCRIPTION
This fixes issue #13 by changing the expected content type (and directory name) from post to posts. The current documentation suggests that `/posts` is the default content type for posts.